### PR TITLE
#1 Todoの一覧表示機能の作成とその他必須要件のためのCRUD処理関数の定義

### DIFF
--- a/app/controllers/Home.scala
+++ b/app/controllers/Home.scala
@@ -1,18 +1,12 @@
-/**
- *
- * to do sample project
- *
- */
-
 package controllers
 
 import javax.inject._
 import play.api.mvc._
 
-import model.ViewValueHome
+import model.viewValue.ViewValueHome
 
 @Singleton
-class HomeController @Inject()(val controllerComponents: ControllerComponents) extends BaseController {
+class HomeController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
 
   def index() = Action { implicit req =>
     val vv = ViewValueHome(

--- a/app/controllers/ToDo.scala
+++ b/app/controllers/ToDo.scala
@@ -22,8 +22,8 @@ class ToDoController @Inject() (
       Ok(views.html.ToDo(
         ViewValueToDo(
           title  = "ToDo List",
-          cssSrc = Seq("styles.css"),
-          jsSrc  = Seq("scripts.js")
+          cssSrc = Seq("todo.css"),
+          jsSrc  = Seq("todo.js")
         ),
         todosWithCategories
       ))

--- a/app/controllers/ToDo.scala
+++ b/app/controllers/ToDo.scala
@@ -1,0 +1,32 @@
+package controllers
+
+import javax.inject._
+import play.api.mvc._
+import scala.concurrent._
+import scala.concurrent.duration._
+import model.{ ToDo, ToDoCategory, ViewValueToDo }
+import play.api.i18n.{ I18nSupport, Messages }
+import persistence.{ ToDoRepository, ToDoCategoryRepository }
+import play.twirl.api.Html
+
+@Singleton
+class ToDoController @Inject() (
+  val controllerComponents: ControllerComponents,
+  todoRepo:                 ToDoRepository
+)(implicit ec:              ExecutionContext) extends BaseController {
+
+  def index() = Action.async { implicit request: Request[AnyContent] =>
+    for {
+      todosWithCategories <- todoRepo.getTodosWithCategories()
+    } yield {
+      Ok(views.html.ToDo(
+        ViewValueToDo(
+          title  = "ToDo List",
+          cssSrc = Seq("styles.css"),
+          jsSrc  = Seq("scripts.js")
+        ),
+        todosWithCategories
+      ))
+    }
+  }
+}

--- a/app/controllers/ToDo.scala
+++ b/app/controllers/ToDo.scala
@@ -4,7 +4,8 @@ import javax.inject._
 import play.api.mvc._
 import scala.concurrent._
 import persistence.ToDoRepository
-import model.{ ToDo, ToDoCategory, ViewValueToDo }
+import model.{ ToDo, ToDoCategory }
+import model.viewValue.ViewValueToDo
 
 @Singleton
 class ToDoController @Inject() (
@@ -22,7 +23,7 @@ class ToDoController @Inject() (
           cssSrc = Seq("todo.css"),
           jsSrc  = Seq("todo.js"),
           todos  = todosWithCategories
-        ),
+        )
       ))
     }
   }

--- a/app/controllers/ToDo.scala
+++ b/app/controllers/ToDo.scala
@@ -3,11 +3,8 @@ package controllers
 import javax.inject._
 import play.api.mvc._
 import scala.concurrent._
-import scala.concurrent.duration._
+import persistence.ToDoRepository
 import model.{ ToDo, ToDoCategory, ViewValueToDo }
-import play.api.i18n.{ I18nSupport, Messages }
-import persistence.{ ToDoRepository, ToDoCategoryRepository }
-import play.twirl.api.Html
 
 @Singleton
 class ToDoController @Inject() (
@@ -23,9 +20,9 @@ class ToDoController @Inject() (
         ViewValueToDo(
           title  = "ToDo List",
           cssSrc = Seq("todo.css"),
-          jsSrc  = Seq("todo.js")
+          jsSrc  = Seq("todo.js"),
+          todos  = todosWithCategories
         ),
-        todosWithCategories
       ))
     }
   }

--- a/app/model/Common.scala
+++ b/app/model/Common.scala
@@ -1,14 +1,12 @@
 /**
- *
- * to do sample project
- *
- */
+  * to do sample project
+  */
 package model
 
 /**
- * 全ページに最低限必要な要素をtrait化。親のhtmlは引数でこのtraitを受け取ることで
- * このtraitを継承したclassも引数に投げることができる
- */
+  * 全ページに最低限必要な要素をtrait化。親のhtmlは引数でこのtraitを受け取ることで
+  * このtraitを継承したclassも引数に投げることができる
+  */
 trait ViewValueCommon {
   val title:  String      // pageのタイトル
   val cssSrc: Seq[String] // pageで読み込むcssのファイル名

--- a/app/model/Home.scala
+++ b/app/model/Home.scala
@@ -1,8 +1,6 @@
 /**
- *
- * to do sample project
- *
- */
+  * to do sample project
+  */
 
 package model
 
@@ -12,4 +10,3 @@ case class ViewValueHome(
   cssSrc: Seq[String],
   jsSrc:  Seq[String],
 ) extends ViewValueCommon
-

--- a/app/model/ToDo.scala
+++ b/app/model/ToDo.scala
@@ -2,7 +2,6 @@ package model
 
 import ixias.model._
 import ixias.util._
-import ixias.util.EnumStatus
 import java.time.LocalDateTime
 import model.{ ToDo, ToDoCategory }
 
@@ -43,4 +42,5 @@ case class ViewValueToDo(
   title:  String,
   cssSrc: Seq[String],
   jsSrc:  Seq[String],
+  todos:  Seq[(ToDo, Option[ToDoCategory])],
 ) extends ViewValueCommon

--- a/app/model/ToDo.scala
+++ b/app/model/ToDo.scala
@@ -4,6 +4,7 @@ import ixias.model._
 import ixias.util._
 import ixias.util.EnumStatus
 import java.time.LocalDateTime
+import model.{ ToDo, ToDoCategory }
 
 // ToDoを表すモデル
 //~~~~~~~~~~~~~~~~~~~~
@@ -36,3 +37,10 @@ object ToDo {
     case object DONE        extends ToDoState(code = 2, name = "完了")
   }
 }
+
+// ToDoページのviewvalue
+case class ViewValueToDo(
+  title:  String,
+  cssSrc: Seq[String],
+  jsSrc:  Seq[String],
+) extends ViewValueCommon

--- a/app/model/ToDo.scala
+++ b/app/model/ToDo.scala
@@ -9,7 +9,7 @@ import model.{ ToDo, ToDoCategory }
 //~~~~~~~~~~~~~~~~~~~~
 case class ToDo(
   id:         Option[ToDo.Id],
-  categoryId: Long,
+  categoryId: ToDoCategory.Id,
   title:      String,
   body:       String,
   state:      ToDo.ToDoState,
@@ -36,11 +36,3 @@ object ToDo {
     case object DONE        extends ToDoState(code = 2, name = "完了")
   }
 }
-
-// ToDoページのviewvalue
-case class ViewValueToDo(
-  title:  String,
-  cssSrc: Seq[String],
-  jsSrc:  Seq[String],
-  todos:  Seq[(ToDo, Option[ToDoCategory])],
-) extends ViewValueCommon

--- a/app/model/ToDo.scala
+++ b/app/model/ToDo.scala
@@ -1,0 +1,38 @@
+package model
+
+import ixias.model._
+import ixias.util._
+import ixias.util.EnumStatus
+import java.time.LocalDateTime
+
+// ToDoを表すモデル
+//~~~~~~~~~~~~~~~~~~~~
+case class ToDo(
+  id:         Option[ToDo.Id],
+  categoryId: Long,
+  title:      String,
+  body:       String,
+  state:      ToDo.ToDoState,
+  updatedAt:  LocalDateTime = NOW,
+  createdAt:  LocalDateTime = NOW
+) extends EntityModel[ToDo.Id]
+
+// コンパニオンオブジェクト
+//~~~~~~~~~~~~~~~~~~~~~~~~
+object ToDo {
+
+  val Id = the[Identity[Id]]
+  type Id         = Long @@ ToDo
+  type WithNoId   = Entity.WithNoId[Id, ToDo]
+  type EmbeddedId = Entity.EmbeddedId[Id, ToDo]
+
+  // ステータス定義
+  //~~~~~~~~~~~~~~~~~
+  sealed abstract class ToDoState(val code: Short, val name: String) extends EnumStatus
+
+  object ToDoState extends EnumStatus.Of[ToDoState] {
+    case object TODO        extends ToDoState(code = 0, name = "TODO(着手前)")
+    case object IN_PROGRESS extends ToDoState(code = 1, name = "進行中")
+    case object DONE        extends ToDoState(code = 2, name = "完了")
+  }
+}

--- a/app/model/ToDoCategory.scala
+++ b/app/model/ToDoCategory.scala
@@ -1,0 +1,37 @@
+package model
+
+import ixias.model._
+import ixias.util._
+import ixias.util.EnumStatus
+import java.time.LocalDateTime
+
+// Categoryを表すモデル
+//~~~~~~~~~~~~~~~~~~~~
+case class ToDoCategory(
+  id:        Option[ToDoCategory.Id],
+  name:      String,
+  slug:      String,
+  color:     ToDoCategory.Color,
+  updatedAt: LocalDateTime = NOW,
+  createdAt: LocalDateTime = NOW
+) extends EntityModel[ToDoCategory.Id]
+
+// コンパニオンオブジェクト
+//~~~~~~~~~~~~~~~~~~~~~~~~
+object ToDoCategory {
+
+  val Id = the[Identity[Id]]
+  type Id         = Long @@ ToDoCategory
+  type WithNoId   = Entity.WithNoId[Id, ToDoCategory]
+  type EmbeddedId = Entity.EmbeddedId[Id, ToDoCategory]
+
+  // ステータス定義
+  //~~~~~~~~~~~~~~~~~
+  sealed abstract class Color(val code: Short, val name: String) extends EnumStatus
+
+  object Color extends EnumStatus.Of[Color] {
+    case object FRONT extends Color(code = 1, name = "#4CAF50")
+    case object BACK  extends Color(code = 2, name = "進行中")
+    case object INFRA extends Color(code = 3, name = "完了")
+  }
+}

--- a/app/model/ToDoCategory.scala
+++ b/app/model/ToDoCategory.scala
@@ -2,7 +2,6 @@ package model
 
 import ixias.model._
 import ixias.util._
-import ixias.util.EnumStatus
 import java.time.LocalDateTime
 
 // Categoryを表すモデル
@@ -30,8 +29,9 @@ object ToDoCategory {
   sealed abstract class Color(val code: Short, val name: String) extends EnumStatus
 
   object Color extends EnumStatus.Of[Color] {
-    case object FRONT extends Color(code = 1, name = "#61DAFB")
-    case object BACK  extends Color(code = 2, name = "#4B8BBE")
-    case object INFRA extends Color(code = 3, name = "#E6522C")
+    case object FRONT extends Color(code = 1, name = "#F2A1A1")
+    case object BACK  extends Color(code = 2, name = "#A1B3F2")
+    case object INFRA extends Color(code = 3, name = "#F2E1A1")
+
   }
 }

--- a/app/model/ToDoCategory.scala
+++ b/app/model/ToDoCategory.scala
@@ -30,8 +30,8 @@ object ToDoCategory {
   sealed abstract class Color(val code: Short, val name: String) extends EnumStatus
 
   object Color extends EnumStatus.Of[Color] {
-    case object FRONT extends Color(code = 1, name = "#4CAF50")
-    case object BACK  extends Color(code = 2, name = "進行中")
-    case object INFRA extends Color(code = 3, name = "完了")
+    case object FRONT extends Color(code = 1, name = "#61DAFB")
+    case object BACK  extends Color(code = 2, name = "#4B8BBE")
+    case object INFRA extends Color(code = 3, name = "#E6522C")
   }
 }

--- a/app/model/ToDoViewValue.scala
+++ b/app/model/ToDoViewValue.scala
@@ -1,0 +1,8 @@
+package model
+// ToDoページのviewvalue
+case class ViewValueToDo(
+  title:  String,
+  cssSrc: Seq[String],
+  jsSrc:  Seq[String],
+  todos:  Seq[(ToDo#EmbeddedId, Option[ToDoCategory#EmbeddedId])],
+) extends ViewValueCommon

--- a/app/model/viewValue/ViewValueHome.scala
+++ b/app/model/viewValue/ViewValueHome.scala
@@ -1,8 +1,6 @@
-/**
-  * to do sample project
-  */
+package model.viewValue
 
-package model
+import model.viewValue.common.ViewValueCommon
 
 // Topページのviewvalue
 case class ViewValueHome(

--- a/app/model/viewValue/ViewValueToDo.scala
+++ b/app/model/viewValue/ViewValueToDo.scala
@@ -1,4 +1,7 @@
-package model
+package model.viewValue
+
+import model.{ ToDo, ToDoCategory }
+import model.viewValue.common.ViewValueCommon
 // ToDoページのviewvalue
 case class ViewValueToDo(
   title:  String,

--- a/app/model/viewValue/common/ViewValueCommon.scala
+++ b/app/model/viewValue/common/ViewValueCommon.scala
@@ -1,7 +1,7 @@
 /**
   * to do sample project
   */
-package model
+package model.viewValue.common
 
 /**
   * 全ページに最低限必要な要素をtrait化。親のhtmlは引数でこのtraitを受け取ることで

--- a/app/modules/DatabaseModule.scala
+++ b/app/modules/DatabaseModule.scala
@@ -1,0 +1,24 @@
+package modules
+
+import javax.inject.{ Inject, Provider, Singleton }
+import scala.concurrent.Future
+import com.google.inject.name.Names
+import com.google.inject.AbstractModule
+import play.api.inject.ApplicationLifecycle
+import ixias.slick.model.DataSourceName
+import ixias.slick.builder._
+import ixias.slick.jdbc.MySQLProfile.api.Database
+
+class DatabaseModule extends AbstractModule {
+
+  override def configure(): Unit = {
+    bind(classOf[Database])
+      .annotatedWith(Names.named("master"))
+      .toProvider(classOf[MasterDatabaseProvider])
+      .asEagerSingleton()
+    bind(classOf[Database])
+      .annotatedWith(Names.named("slave"))
+      .toProvider(classOf[SlaveDatabaseProvider])
+      .asEagerSingleton()
+  }
+}

--- a/app/modules/MasterDatabaseProvider.scala
+++ b/app/modules/MasterDatabaseProvider.scala
@@ -1,0 +1,31 @@
+package modules
+
+import javax.inject.{ Inject, Provider, Singleton }
+import scala.concurrent.Future
+import com.google.inject.name.Names
+import com.google.inject.AbstractModule
+import play.api.inject.ApplicationLifecycle
+import ixias.slick.model.DataSourceName
+import ixias.slick.builder._
+import ixias.slick.jdbc.MySQLProfile.api.Database
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+
+
+@Singleton
+class MasterDatabaseProvider @Inject() (
+  lifecycle: ApplicationLifecycle
+) extends Provider[Database] {
+
+  private val hikariConfigBuilder = HikariConfigBuilder.default(DataSourceName("ixias.db.mysql://master/to_do"))
+  private val hikariConfig        = hikariConfigBuilder.build()
+  hikariConfig.validate()
+
+  private val dataSource = new HikariDataSource(hikariConfig)
+
+  lifecycle.addStopHook { () =>
+    Future.successful(dataSource.close())
+  }
+
+  override def get(): Database = DatabaseBuilder.fromHikariDataSource(dataSource)
+}

--- a/app/modules/SlaveDatabaseProvider.scala
+++ b/app/modules/SlaveDatabaseProvider.scala
@@ -1,0 +1,32 @@
+package modules
+
+
+import javax.inject.{ Inject, Provider, Singleton }
+import scala.concurrent.Future
+import com.google.inject.name.Names
+import com.google.inject.AbstractModule
+import play.api.inject.ApplicationLifecycle
+import ixias.slick.model.DataSourceName
+import ixias.slick.builder._
+import ixias.slick.jdbc.MySQLProfile.api.Database
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+
+
+@Singleton
+class SlaveDatabaseProvider @Inject() (
+  lifecycle: ApplicationLifecycle
+) extends Provider[Database] {
+
+  private val hikariConfigBuilder = HikariConfigBuilder.default(DataSourceName("ixias.db.mysql://slave/to_do"))
+  private val hikariConfig        = hikariConfigBuilder.build()
+  hikariConfig.validate()
+
+  private val dataSource = new HikariDataSource(hikariConfig)
+
+  lifecycle.addStopHook { () =>
+    Future.successful(dataSource.close())
+  }
+
+  override def get(): Database = DatabaseBuilder.fromHikariDataSource(dataSource)
+}

--- a/app/persistence/ToDo.scala
+++ b/app/persistence/ToDo.scala
@@ -1,17 +1,12 @@
 package persistence
 
 import scala.concurrent.{ ExecutionContext, Future }
-import ixias.model._
 import ixias.slick.SlickRepository
-import ixias.slick.builder.{ DatabaseBuilder, HikariConfigBuilder }
 import ixias.slick.jdbc.MySQLProfile.api._
-import ixias.slick.model.DataSourceName
 import model.{ ToDo, ToDoCategory }
-import model.ToDo.Id
 import persistence.db.{ ToDoTable, ToDoCategoryTable }
-import slick.dbio.Effect
-import slick.sql.FixedSqlAction
 import javax.inject._
+
 // ToDoRepository: ToDoTableへのクエリ発行を行うRepository層の定義
 //~~~~~~~~~~~~~~~~~~~~~~
 @Singleton

--- a/app/persistence/ToDo.scala
+++ b/app/persistence/ToDo.scala
@@ -1,0 +1,82 @@
+package persistence
+
+import com.zaxxer.hikari.HikariDataSource
+
+import scala.concurrent.{ ExecutionContext, Future }
+import ixias.model._
+import ixias.slick.SlickRepository
+import ixias.slick.builder.{ DatabaseBuilder, HikariConfigBuilder }
+import ixias.slick.jdbc.MySQLProfile.api._
+import ixias.slick.model.DataSourceName
+import model.{ ToDo, ToDoCategory }
+import model.ToDo.Id
+import persistence.db.{ ToDoTable, ToDoCategoryTable }
+import slick.dbio.Effect
+import slick.sql.FixedSqlAction
+
+// ToDoRepository: ToDoTableへのクエリ発行を行うRepository層の定義
+//~~~~~~~~~~~~~~~~~~~~~~
+class ToDoRepository()(implicit val ec: ExecutionContext) extends SlickRepository[ToDo.Id, ToDo] {
+  val master: Database = DatabaseBuilder.fromHikariDataSource(
+    new HikariDataSource(HikariConfigBuilder.default(DataSourceName("ixias.db.mysql://master/user")).build())
+  )
+  val slave:  Database = DatabaseBuilder.fromHikariDataSource(
+    new HikariDataSource(HikariConfigBuilder.default(DataSourceName("ixias.db.mysql://slave/user")).build())
+  )
+
+  val todoTable     = TableQuery[ToDoTable]
+  val categoryTable = TableQuery[ToDoCategoryTable]
+
+  /**
+    * Get ToDo Data
+    */
+  def getById(id: ToDo.Id): Future[Option[ToDo]] = {
+    slave.run(todoTable.filter(_.id === id).result.headOption)
+  }
+
+  /**
+    * Get All ToDo Data with Category Information
+    */
+  def getAllWithCategories: Future[Seq[(ToDo, Option[ToDoCategory])]] = {
+    val query = todoTable
+      .joinLeft(categoryTable)
+      .on(_.categoryId === _.id)
+      .result
+      .map(_.map {
+        case (todo, categoryOpt) => (todo, categoryOpt)
+      })
+
+    slave.run(query)
+  }
+
+  /**
+    * Add ToDo Data
+    */
+  def add(todo: ToDo#WithNoId): Future[ToDo.Id] = {
+    master.run(todoTable returning todoTable.map(_.id) += todo.v)
+  }
+
+  /**
+    * Update ToDo Data
+    */
+  def update(entity: ToDo#EmbeddedId): Future[Option[ToDo#EmbeddedId]] = {
+    master.run {
+      todoTable.filter(_.id === entity.id).update(entity.v).map(_ > 0).map {
+        case true  => Some(entity)
+        case false => None
+      }
+    }
+  }
+
+  /**
+    * Delete ToDo Data
+    */
+  def remove(id: ToDo.Id): Future[Option[ToDo#EmbeddedId]] = {
+    master.run {
+      todoTable.filter(_.id === id).delete.map {
+        case 0 => None
+        case _ => Some(id.asInstanceOf[ToDo#EmbeddedId])
+      }
+    }
+  }
+}

--- a/app/persistence/ToDo.scala
+++ b/app/persistence/ToDo.scala
@@ -18,7 +18,7 @@ import javax.inject._
 class ToDoRepository @Inject() (
   @Named("master") master: Database,
   @Named("slave") slave:   Database
-)(implicit val ec:                   ExecutionContext) extends SlickRepository[ToDo.Id, ToDo] {
+)(implicit val ec:         ExecutionContext) extends SlickRepository[ToDo.Id, ToDo] {
 
   val todoTable         = TableQuery[ToDoTable]
   val todoCategoryTable = TableQuery[ToDoCategoryTable]
@@ -30,9 +30,12 @@ class ToDoRepository @Inject() (
     slave.run(todoTable.filter(_.id === id).result.headOption)
   }
 
+  /**
+    * Get ToDo Data　With Category
+    */
   def getTodosWithCategories(): Future[Seq[(ToDo, Option[ToDoCategory])]] = {
     val queryWithLeftJoin = for {
-      (todo, categoryOpt) <- todoTable joinLeft todoCategoryTable on (_.category_id === _.id)
+      (todo, categoryOpt) <- todoTable joinLeft todoCategoryTable on (_.categoryId === _.id)
     } yield (todo, categoryOpt)
 
     slave.run(queryWithLeftJoin.result)

--- a/app/persistence/ToDo.scala
+++ b/app/persistence/ToDo.scala
@@ -32,7 +32,7 @@ class ToDoRepository @Inject() (
 
   def getTodosWithCategories(): Future[Seq[(ToDo, Option[ToDoCategory])]] = {
     val queryWithLeftJoin = for {
-      (todo, categoryOpt) <- todoTable joinLeft todoCategoryTable on (_.categoryId === _.id)
+      (todo, categoryOpt) <- todoTable joinLeft todoCategoryTable on (_.category_id === _.id)
     } yield (todo, categoryOpt)
 
     slave.run(queryWithLeftJoin.result)

--- a/app/persistence/ToDoCategory.scala
+++ b/app/persistence/ToDoCategory.scala
@@ -3,16 +3,10 @@ package persistence
 import com.zaxxer.hikari.HikariDataSource
 
 import scala.concurrent.{ ExecutionContext, Future }
-import ixias.model._
 import ixias.slick.SlickRepository
-import ixias.slick.builder.{ DatabaseBuilder, HikariConfigBuilder }
 import ixias.slick.jdbc.MySQLProfile.api._
-import ixias.slick.model.DataSourceName
 import model.ToDoCategory
-import model.ToDoCategory.Id
 import persistence.db.ToDoCategoryTable
-import slick.dbio.Effect
-import slick.sql.FixedSqlAction
 import javax.inject._
 
 // ToDoRepository: ToDoTableへのクエリ発行を行うRepository層の定義
@@ -21,7 +15,7 @@ import javax.inject._
 class ToDoCategoryRepository @Inject() (
   @Named("master") master: Database,
   @Named("slave") slave:   Database
-)(implicit val ec:                   ExecutionContext) extends SlickRepository[ToDoCategory.Id, ToDoCategory] {
+)(implicit val ec:         ExecutionContext) extends SlickRepository[ToDoCategory.Id, ToDoCategory] {
 
   val todoCategoryTable = TableQuery[ToDoCategoryTable]
 

--- a/app/persistence/ToDoCategory.scala
+++ b/app/persistence/ToDoCategory.scala
@@ -13,16 +13,15 @@ import model.ToDoCategory.Id
 import persistence.db.ToDoCategoryTable
 import slick.dbio.Effect
 import slick.sql.FixedSqlAction
+import javax.inject._
 
 // ToDoRepository: ToDoTableへのクエリ発行を行うRepository層の定義
 //~~~~~~~~~~~~~~~~~~~~~~
-class ToDoCategoryRepository()(implicit val ec: ExecutionContext) extends SlickRepository[ToDoCategory.Id, ToDoCategory] {
-  val master: Database = DatabaseBuilder.fromHikariDataSource(
-    new HikariDataSource(HikariConfigBuilder.default(DataSourceName("ixias.db.mysql://master/user")).build())
-  )
-  val slave:  Database = DatabaseBuilder.fromHikariDataSource(
-    new HikariDataSource(HikariConfigBuilder.default(DataSourceName("ixias.db.mysql://slave/user")).build())
-  )
+@Singleton
+class ToDoCategoryRepository @Inject() (
+  @Named("master") master: Database,
+  @Named("slave") slave:   Database
+)(implicit val ec:                   ExecutionContext) extends SlickRepository[ToDoCategory.Id, ToDoCategory] {
 
   val todoCategoryTable = TableQuery[ToDoCategoryTable]
 

--- a/app/persistence/ToDoCategory.scala
+++ b/app/persistence/ToDoCategory.scala
@@ -1,0 +1,66 @@
+package persistence
+
+import com.zaxxer.hikari.HikariDataSource
+
+import scala.concurrent.{ ExecutionContext, Future }
+import ixias.model._
+import ixias.slick.SlickRepository
+import ixias.slick.builder.{ DatabaseBuilder, HikariConfigBuilder }
+import ixias.slick.jdbc.MySQLProfile.api._
+import ixias.slick.model.DataSourceName
+import model.ToDoCategory
+import model.ToDoCategory.Id
+import persistence.db.ToDoCategoryTable
+import slick.dbio.Effect
+import slick.sql.FixedSqlAction
+
+// ToDoRepository: ToDoTableへのクエリ発行を行うRepository層の定義
+//~~~~~~~~~~~~~~~~~~~~~~
+class ToDoCategoryRepository()(implicit val ec: ExecutionContext) extends SlickRepository[ToDoCategory.Id, ToDoCategory] {
+  val master: Database = DatabaseBuilder.fromHikariDataSource(
+    new HikariDataSource(HikariConfigBuilder.default(DataSourceName("ixias.db.mysql://master/user")).build())
+  )
+  val slave:  Database = DatabaseBuilder.fromHikariDataSource(
+    new HikariDataSource(HikariConfigBuilder.default(DataSourceName("ixias.db.mysql://slave/user")).build())
+  )
+
+  val todoCategoryTable = TableQuery[ToDoCategoryTable]
+
+  /**
+    * Get ToDoCategory Data
+    */
+  def getById(id: ToDoCategory.Id): Future[Option[ToDoCategory]] = {
+    slave.run(todoCategoryTable.filter(_.id === id).result.headOption)
+  }
+
+  /**
+    * Add ToDoCategory Data
+    */
+  def add(category: ToDoCategory#WithNoId): Future[ToDoCategory.Id] = {
+    master.run(todoCategoryTable returning todoCategoryTable.map(_.id) += category.v)
+  }
+
+  /**
+    * Update ToDoCategory Data
+    */
+  def update(entity: ToDoCategory#EmbeddedId): Future[Option[ToDoCategory#EmbeddedId]] = {
+    master.run {
+      todoCategoryTable.filter(_.id === entity.id).update(entity.v).map(_ > 0).map {
+        case true  => Some(entity)
+        case false => None
+      }
+    }
+  }
+
+  /**
+    * Delete ToDoCategory Data
+    */
+  def remove(id: ToDoCategory.Id): Future[Option[ToDoCategory#EmbeddedId]] = {
+    master.run {
+      todoCategoryTable.filter(_.id === id).delete.map {
+        case 0 => None
+        case _ => Some(id.asInstanceOf[ToDoCategory#EmbeddedId])
+      }
+    }
+  }
+}

--- a/app/persistence/ToDoCategory.scala
+++ b/app/persistence/ToDoCategory.scala
@@ -9,7 +9,7 @@ import model.ToDoCategory
 import persistence.db.ToDoCategoryTable
 import javax.inject._
 
-// ToDoRepository: ToDoTableへのクエリ発行を行うRepository層の定義
+// ToDoCategoryRepository: ToDoCategoryTableへのクエリ発行を行うRepository層の定義
 //~~~~~~~~~~~~~~~~~~~~~~
 @Singleton
 class ToDoCategoryRepository @Inject() (

--- a/app/persistence/db/ToDo.scala
+++ b/app/persistence/db/ToDo.scala
@@ -8,7 +8,7 @@ import persistence.db.ToDoCategoryTable
 
 import java.time
 
-// UserTable: Userテーブルへのマッピングを行う
+//　ToDoTable: ToDoテーブルへのマッピングを行う
 //~~~~~~~~~~~~~~
 case class ToDoTable(tag: Tag) extends Table[ToDo](tag, "to_do") {
   def id         = column[ToDo.Id]("id", UInt64, O.PrimaryKey, O.AutoInc)

--- a/app/persistence/db/ToDo.scala
+++ b/app/persistence/db/ToDo.scala
@@ -10,9 +10,9 @@ import java.time
 
 // UserTable: Userテーブルへのマッピングを行う
 //~~~~~~~~~~~~~~
-case class ToDoTable(tag: Tag) extends Table[ToDo](tag, "todo") {
+case class ToDoTable(tag: Tag) extends Table[ToDo](tag, "to_do") {
   def id         = column[ToDo.Id]("id", UInt64, O.PrimaryKey, O.AutoInc)
-  def categoryId = column[Long]("categoryId", UInt64)
+  def category_id = column[Long]("category_id", UInt64)
   def title      = column[String]("title", Utf8Char255)
   def body       = column[String]("body", Text)
   def state      = column[ToDo.ToDoState]("state", UInt8)
@@ -20,7 +20,7 @@ case class ToDoTable(tag: Tag) extends Table[ToDo](tag, "todo") {
   def createdAt  = column[LocalDateTime]("created_at", Ts)
 
   // DB <=> Scala の相互のmapping定義
-  def * = (id.?, categoryId, title, body, state, updatedAt, createdAt).<>(
+  def * = (id.?, category_id, title, body, state, updatedAt, createdAt).<>(
     (ToDo.apply _).tupled,
     (ToDo.unapply _).andThen(_.map(_.copy(
       _6 = LocalDateTime.now()

--- a/app/persistence/db/ToDo.scala
+++ b/app/persistence/db/ToDo.scala
@@ -3,7 +3,7 @@ package persistence.db
 import java.time.LocalDateTime
 import ixias.slick.jdbc.MySQLProfile.api._
 import ixias.slick.builder._
-import model.ToDo
+import model.{ ToDo, ToDoCategory }
 import persistence.db.ToDoCategoryTable
 
 import java.time
@@ -12,7 +12,7 @@ import java.time
 //~~~~~~~~~~~~~~
 case class ToDoTable(tag: Tag) extends Table[ToDo](tag, "to_do") {
   def id         = column[ToDo.Id]("id", UInt64, O.PrimaryKey, O.AutoInc)
-  def categoryId = column[Long]("category_id", UInt64)
+  def categoryId = column[ToDoCategory.Id]("category_id", UInt64)
   def title      = column[String]("title", Utf8Char255)
   def body       = column[String]("body", Text)
   def state      = column[ToDo.ToDoState]("state", UInt8)

--- a/app/persistence/db/ToDo.scala
+++ b/app/persistence/db/ToDo.scala
@@ -12,7 +12,7 @@ import java.time
 //~~~~~~~~~~~~~~
 case class ToDoTable(tag: Tag) extends Table[ToDo](tag, "to_do") {
   def id         = column[ToDo.Id]("id", UInt64, O.PrimaryKey, O.AutoInc)
-  def category_id = column[Long]("category_id", UInt64)
+  def categoryId = column[Long]("category_id", UInt64)
   def title      = column[String]("title", Utf8Char255)
   def body       = column[String]("body", Text)
   def state      = column[ToDo.ToDoState]("state", UInt8)
@@ -20,7 +20,7 @@ case class ToDoTable(tag: Tag) extends Table[ToDo](tag, "to_do") {
   def createdAt  = column[LocalDateTime]("created_at", Ts)
 
   // DB <=> Scala の相互のmapping定義
-  def * = (id.?, category_id, title, body, state, updatedAt, createdAt).<>(
+  def * = (id.?, categoryId, title, body, state, updatedAt, createdAt).<>(
     (ToDo.apply _).tupled,
     (ToDo.unapply _).andThen(_.map(_.copy(
       _6 = LocalDateTime.now()

--- a/app/persistence/db/ToDo.scala
+++ b/app/persistence/db/ToDo.scala
@@ -1,0 +1,29 @@
+package persistence.db
+
+import java.time.LocalDateTime
+import ixias.slick.jdbc.MySQLProfile.api._
+import ixias.slick.builder._
+import model.ToDo
+import persistence.db.ToDoCategoryTable
+
+import java.time
+
+// UserTable: Userテーブルへのマッピングを行う
+//~~~~~~~~~~~~~~
+case class ToDoTable(tag: Tag) extends Table[ToDo](tag, "todo") {
+  def id         = column[ToDo.Id]("id", UInt64, O.PrimaryKey, O.AutoInc)
+  def categoryId = column[Long]("categoryId", UInt64)
+  def title      = column[String]("title", Utf8Char255)
+  def body       = column[String]("body", Text)
+  def state      = column[ToDo.ToDoState]("state", UInt8)
+  def updatedAt  = column[LocalDateTime]("updated_at", TsCurrent)
+  def createdAt  = column[LocalDateTime]("created_at", Ts)
+
+  // DB <=> Scala の相互のmapping定義
+  def * = (id.?, categoryId, title, body, state, updatedAt, createdAt).<>(
+    (ToDo.apply _).tupled,
+    (ToDo.unapply _).andThen(_.map(_.copy(
+      _6 = LocalDateTime.now()
+    )))
+  )
+}

--- a/app/persistence/db/ToDoCategory.scala
+++ b/app/persistence/db/ToDoCategory.scala
@@ -7,7 +7,7 @@ import model.ToDoCategory
 
 import java.time
 
-// UserTable: Userテーブルへのマッピングを行う
+// ToDoCategoryTable: ToDoCategoryテーブルへのマッピングを行う
 //~~~~~~~~~~~~~~
 case class ToDoCategoryTable(tag: Tag) extends Table[ToDoCategory](tag, "to_do_category") {
   def id        = column[ToDoCategory.Id]("id", UInt64, O.PrimaryKey, O.AutoInc)

--- a/app/persistence/db/ToDoCategory.scala
+++ b/app/persistence/db/ToDoCategory.scala
@@ -9,7 +9,7 @@ import java.time
 
 // UserTable: Userテーブルへのマッピングを行う
 //~~~~~~~~~~~~~~
-case class ToDoCategoryTable(tag: Tag) extends Table[ToDoCategory](tag, "todoCategory") {
+case class ToDoCategoryTable(tag: Tag) extends Table[ToDoCategory](tag, "to_do_category") {
   def id        = column[ToDoCategory.Id]("id", UInt64, O.PrimaryKey, O.AutoInc)
   def name      = column[String]("name", Utf8Char255)
   def slug      = column[String]("slug", AsciiChar64)

--- a/app/persistence/db/ToDoCategory.scala
+++ b/app/persistence/db/ToDoCategory.scala
@@ -1,0 +1,27 @@
+package persistence.db
+
+import java.time.LocalDateTime
+import ixias.slick.jdbc.MySQLProfile.api._
+import ixias.slick.builder._
+import model.ToDoCategory
+
+import java.time
+
+// UserTable: Userテーブルへのマッピングを行う
+//~~~~~~~~~~~~~~
+case class ToDoCategoryTable(tag: Tag) extends Table[ToDoCategory](tag, "todoCategory") {
+  def id        = column[ToDoCategory.Id]("id", UInt64, O.PrimaryKey, O.AutoInc)
+  def name      = column[String]("name", Utf8Char255)
+  def slug      = column[String]("slug", AsciiChar64)
+  def color     = column[ToDoCategory.Color]("color", UInt8)
+  def updatedAt = column[LocalDateTime]("updated_at", TsCurrent)
+  def createdAt = column[LocalDateTime]("created_at", Ts)
+
+  // DB <=> Scala の相互のmapping定義
+  def * = (id.?, name, slug, color, updatedAt, createdAt).<>(
+    (ToDoCategory.apply _).tupled,
+    (ToDoCategory.unapply _).andThen(_.map(_.copy(
+      _5 = LocalDateTime.now()
+    )))
+  )
+}

--- a/app/views/Home.scala.html
+++ b/app/views/Home.scala.html
@@ -1,10 +1,4 @@
-@*
- *
- * to do sample project
- *
- *@
-
-@(vv: model.ViewValueCommon)
+@(vv: model.viewValue.ViewValueHome)
 @common.Default(vv){
    <ul>
     <li><a>カテゴリー一覧</a></li>

--- a/app/views/Home.scala.html
+++ b/app/views/Home.scala.html
@@ -8,6 +8,6 @@
 @common.Default(vv){
    <ul>
     <li><a>カテゴリー一覧</a></li>
-    <li><a>Todo一覧</a></li>
+    <li><a href="@routes.ToDoController.index()">Todo一覧</a></li>
  </ul>
 }

--- a/app/views/ToDo.scala.html
+++ b/app/views/ToDo.scala.html
@@ -1,7 +1,8 @@
-@import model._
+@import model.{ ToDo, ToDoCategory }
+@import model.viewValue.ViewValueToDo
 @import java.time.format.DateTimeFormatter
 
-@(vv: model.ViewValueToDo)
+@(vv: model.viewValue.ViewValueToDo)
 @common.Default(vv){
 <ul>
   <li><a href="@routes.HomeController.index()">Home</a></li>

--- a/app/views/ToDo.scala.html
+++ b/app/views/ToDo.scala.html
@@ -7,6 +7,7 @@
   <li><a href="@routes.HomeController.index()">Home</a></li>
   <li><a>カテゴリー一覧</a></li>
 </ul>
+
 <div class="todo-div">
   <div class="legend">
     <div><span style="background-color: @ToDoCategory.Color.FRONT.name"></span> フロントエンド</div>
@@ -14,25 +15,24 @@
     <div><span style="background-color: @ToDoCategory.Color.INFRA.name"></span> インフラ</div>
   </div>
   <div class="todo-list">
-    @for((todo, categoryOpt) <- vv.todos) {
-      <div class="todo-item">
-        <div class="todo-content">
-          <div class="todo-title">@todo.title</div>
-          <div class="todo-body">@todo.body</div>
-          <div class="todo-dates">
-            @defining(DateTimeFormatter.ofPattern("yyyy-MM-dd")) { dateFormatter =>
-            <div>作成日: @todo.createdAt.format(dateFormatter)</div>
-            <div>更新日: @todo.updatedAt.format(dateFormatter)</div>
-            }
-          </div>
-        </div>
-        <div class="todo-status-category">
-          <div class="todo-status">@todo.state.name</div>
-          <div class="todo-category">
-            <span class="category-color" style="background-color: @categoryOpt.fold("#FFFFFF")(_.color.name)"></span>
-          </div>
+    @for((todo, categoryOpt) <- vv.todos) { <div class="todo-item">
+      <div class="todo-content">
+        <div class="todo-title">@todo.v.title</div>
+        <div class="todo-body">@todo.v.body</div>
+        <div class="todo-dates">
+          @defining(DateTimeFormatter.ofPattern("yyyy-MM-dd")) { dateFormatter =>
+          <div>作成日: @todo.v.createdAt.format(dateFormatter)</div>
+          <div>更新日: @todo.v.updatedAt.format(dateFormatter)</div>
+          }
         </div>
       </div>
-    }
+      <div class="todo-status-category">
+        <div class="todo-status">@todo.v.state.name</div>
+        <div class="todo-category">
+          <span class="category-color" style="background-color: @categoryOpt.fold(" #FFFFFF")(_.v.color.name)"></span>
+        </div>
+      </div>
   </div>
+  }
+</div>
 }

--- a/app/views/ToDo.scala.html
+++ b/app/views/ToDo.scala.html
@@ -1,15 +1,42 @@
 @import model._
+@import java.time.format.DateTimeFormatter
+
 @(vv: model.ViewValueToDo, todos: Seq[(ToDo, Option[ToDoCategory])])
 @common.Default(vv){
-  <ul>
-    <li><a href="@routes.HomeController.index()">Home</a></li>
-    <li><a>カテゴリー一覧</a></li>
-  </ul>
-  <ul>
-    @for((todo, categoryOpt) <- todos) {
-      <li style="background-color: @categoryOpt.fold("#FFFFFF")(_.color.name)">
-        <strong>@todo.title</strong> - @todo.body
-      </li>
-    }
-  </ul>
+<ul>
+  <li><a href="@routes.HomeController.index()">Home</a></li>
+  <li><a>カテゴリー一覧</a></li>
+</ul>
+<div class="table-div">
+  <div class="legend">
+    <div><span style="background-color: #61DAFB;"></span> フロントエンド</div>
+    <div><span style="background-color: #4B8BBE;"></span> バックエンド</div>
+    <div><span style="background-color: #E6522C;"></span> インフラ</div>
+  </div>
+  <table border="1" cellspacing="0" cellpadding="5">
+    <thead>
+      <tr>
+        <th>タイトル</th>
+        <th>詳細</th>
+        <th>ステータス</th>
+        <th>カテゴリ</th>
+        <th>作成日時</th>
+        <th>更新日時</th>
+      </tr>
+    </thead>
+    <tbody>
+      @for((todo, categoryOpt) <- todos) { <tr style="background-color: @categoryOpt.fold(" #FFFFFF")(_.color.name)">
+        <td>@todo.title</td>
+        <td>@todo.body</td>
+        <td>@todo.state.name</td>
+        <td>@categoryOpt.fold("未分類")(_.name)</td>
+        @defining(DateTimeFormatter.ofPattern("yyyy-MM-dd")) { dateFormatter =>
+        <td>@todo.createdAt.format(dateFormatter)</td>
+        <td>@todo.updatedAt.format(dateFormatter)</td>
+        }
+        </tr>
+        }
+    </tbody>
+  </table>
+</div>
 }

--- a/app/views/ToDo.scala.html
+++ b/app/views/ToDo.scala.html
@@ -7,36 +7,32 @@
   <li><a href="@routes.HomeController.index()">Home</a></li>
   <li><a>カテゴリー一覧</a></li>
 </ul>
-<div class="table-div">
+<div class="todo-div">
   <div class="legend">
     <div><span style="background-color: @ToDoCategory.Color.FRONT.name"></span> フロントエンド</div>
     <div><span style="background-color: @ToDoCategory.Color.BACK.name"></span> バックエンド</div>
     <div><span style="background-color: @ToDoCategory.Color.INFRA.name"></span> インフラ</div>
   </div>
-  <table border="1" cellspacing="0" cellpadding="5">
-    <thead>
-      <tr>
-        <th>タイトル</th>
-        <th>詳細</th>
-        <th>ステータス</th>
-        <th>カテゴリ</th>
-        <th>作成日時</th>
-        <th>更新日時</th>
-      </tr>
-    </thead>
-    <tbody>
-      @for((todo, categoryOpt) <- vv.todos) { <tr style="background-color: @categoryOpt.fold(" #FFFFFF")(_.color.name)">
-        <td>@todo.title</td>
-        <td>@todo.body</td>
-        <td>@todo.state.name</td>
-        <td>@categoryOpt.fold("未分類")(_.name)</td>
-        @defining(DateTimeFormatter.ofPattern("yyyy-MM-dd")) { dateFormatter =>
-        <td>@todo.createdAt.format(dateFormatter)</td>
-        <td>@todo.updatedAt.format(dateFormatter)</td>
-        }
-        </tr>
-        }
-    </tbody>
-  </table>
-</div>
+  <div class="todo-list">
+    @for((todo, categoryOpt) <- vv.todos) {
+      <div class="todo-item">
+        <div class="todo-content">
+          <div class="todo-title">@todo.title</div>
+          <div class="todo-body">@todo.body</div>
+          <div class="todo-dates">
+            @defining(DateTimeFormatter.ofPattern("yyyy-MM-dd")) { dateFormatter =>
+            <div>作成日: @todo.createdAt.format(dateFormatter)</div>
+            <div>更新日: @todo.updatedAt.format(dateFormatter)</div>
+            }
+          </div>
+        </div>
+        <div class="todo-status-category">
+          <div class="todo-status">@todo.state.name</div>
+          <div class="todo-category">
+            <span class="category-color" style="background-color: @categoryOpt.fold("#FFFFFF")(_.color.name)"></span>
+          </div>
+        </div>
+      </div>
+    }
+  </div>
 }

--- a/app/views/ToDo.scala.html
+++ b/app/views/ToDo.scala.html
@@ -1,7 +1,7 @@
 @import model._
 @import java.time.format.DateTimeFormatter
 
-@(vv: model.ViewValueToDo, todos: Seq[(ToDo, Option[ToDoCategory])])
+@(vv: model.ViewValueToDo)
 @common.Default(vv){
 <ul>
   <li><a href="@routes.HomeController.index()">Home</a></li>
@@ -9,9 +9,9 @@
 </ul>
 <div class="table-div">
   <div class="legend">
-    <div><span style="background-color: #61DAFB;"></span> フロントエンド</div>
-    <div><span style="background-color: #4B8BBE;"></span> バックエンド</div>
-    <div><span style="background-color: #E6522C;"></span> インフラ</div>
+    <div><span style="background-color: @ToDoCategory.Color.FRONT.name"></span> フロントエンド</div>
+    <div><span style="background-color: @ToDoCategory.Color.BACK.name"></span> バックエンド</div>
+    <div><span style="background-color: @ToDoCategory.Color.INFRA.name"></span> インフラ</div>
   </div>
   <table border="1" cellspacing="0" cellpadding="5">
     <thead>
@@ -25,7 +25,7 @@
       </tr>
     </thead>
     <tbody>
-      @for((todo, categoryOpt) <- todos) { <tr style="background-color: @categoryOpt.fold(" #FFFFFF")(_.color.name)">
+      @for((todo, categoryOpt) <- vv.todos) { <tr style="background-color: @categoryOpt.fold(" #FFFFFF")(_.color.name)">
         <td>@todo.title</td>
         <td>@todo.body</td>
         <td>@todo.state.name</td>

--- a/app/views/ToDo.scala.html
+++ b/app/views/ToDo.scala.html
@@ -1,0 +1,11 @@
+@import model._
+@(vv: model.ViewValueToDo, todos: Seq[(ToDo, Option[ToDoCategory])])
+@common.Default(vv){
+   <ul>
+    @for((todo, categoryOpt) <- todos) {
+      <li style="background-color: @categoryOpt.fold("#FFFFFF")(_.color.name)">
+        <strong>@todo.title</strong> - @todo.body
+      </li>
+    }
+ </ul>
+}

--- a/app/views/ToDo.scala.html
+++ b/app/views/ToDo.scala.html
@@ -1,11 +1,15 @@
 @import model._
 @(vv: model.ViewValueToDo, todos: Seq[(ToDo, Option[ToDoCategory])])
 @common.Default(vv){
-   <ul>
+  <ul>
+    <li><a href="@routes.HomeController.index()">Home</a></li>
+    <li><a>カテゴリー一覧</a></li>
+  </ul>
+  <ul>
     @for((todo, categoryOpt) <- todos) {
       <li style="background-color: @categoryOpt.fold("#FFFFFF")(_.color.name)">
         <strong>@todo.title</strong> - @todo.body
       </li>
     }
- </ul>
+  </ul>
 }

--- a/app/views/common/Default.scala.html
+++ b/app/views/common/Default.scala.html
@@ -4,7 +4,7 @@
 * two arguments, a `String` for the title of the page and an `Html`
 * object to insert into the body of the page.
 *@
-@(vv: model.ViewValueCommon)(content: Html)
+@(vv: model.viewValue.common.ViewValueCommon)(content: Html)
 
 <!DOCTYPE html>
 <html lang="ja">

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,20 +1,20 @@
 # https://www.playframework.com/documentation/latest/Configuration
 
+play.modules.enabled += "modules.DatabaseModule"
+
 ixias.db.mysql {
   username = "docker"
   password = "docker"
-  driver_class_name = "com.mysql.jdbc.Driver"
+  driver_class_name = "com.mysql.cj.jdbc.Driver"
   hostspec.master.readonly      = false
   hostspec.master.max_pool_size = 1
   hostspec.slave.readonly       = true
   hostspec.slave.max_pool_size  = 1
-  play.modules.enabled += "modules.DatabaseModule"
 
 
   to_do {
     database               = "to_do"
-    hostspec.master.hosts  = "127.0.0.1:33306"
-    hostspec.slave.hosts   = "127.0.0.1:33306"
+    hostspec.master.jdbc_url = "jdbc:mysql://127.0.0.1:33306/to_do"
+    hostspec.slave.jdbc_url  = "jdbc:mysql://127.0.0.1:33306/to_do"
   }
 }
-

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,6 +8,8 @@ ixias.db.mysql {
   hostspec.master.max_pool_size = 1
   hostspec.slave.readonly       = true
   hostspec.slave.max_pool_size  = 1
+  play.modules.enabled += "modules.DatabaseModule"
+
 
   to_do {
     database               = "to_do"

--- a/conf/routes
+++ b/conf/routes
@@ -5,7 +5,7 @@
 
 # An example controller showing a sample home page
 GET     /                             controllers.HomeController.index()
-GET     /todo                           controllers.ToDoController.index()
+GET     /todos                           controllers.ToDoController.index()
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/routes
+++ b/conf/routes
@@ -5,6 +5,7 @@
 
 # An example controller showing a sample home page
 GET     /                             controllers.HomeController.index()
+GET     /todo                           controllers.ToDoController.index()
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -3,39 +3,42 @@
  */
 
 body {
-  margin:   0;
-  padding:  0;
+  margin: 0;
+  padding: 0;
 }
 
 .header {
-  height:            70px;
-  background-color:  #24292F;
-  width:             100%;
+  height: 70px;
+  background-color: #24292F;
+  width: 100%;
 }
 
 .header .header__content {
-  width:      1080px;
-  margin:     auto;
+  width: 100%;
+  margin: auto;
 }
 
 .header .header__logo {
-  color:             white;
-  line-height:       70px;
-  font-size:         20px;
-  font-weight:       bold;
+  color: white;
+  line-height: 70px;
+  font-size: 20px;
+  font-weight: bold;
 }
 
 .main {
-  width:      980px;
-  margin:     100px auto;
-  padding:    100px;
-  box-shadow: 0 0 4px gray;
-  position:   relative;
+  width: 80%;
+  margin: 100px auto;
+  padding: 100px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: baseline;
 }
 
 .success-message {
-  margin:      30px 0;
-  text-align:  center;
+  margin: 30px 0;
+  text-align: center;
 }
 
 

--- a/public/stylesheets/todo.css
+++ b/public/stylesheets/todo.css
@@ -2,45 +2,101 @@
  * to-do list
  */
 
- body {
-    margin:   0;
-    padding:  0;
-  }
-  
-  .header {
-    height:            70px;
-    background-color:  #24292F;
-    width:             100%;
-  }
-  
-  .header .header__content {
-    width:      1080px;
-    margin:     auto;
-  }
-  
-  .header .header__logo {
-    color:             white;
-    line-height:       70px;
-    font-size:         20px;
-    font-weight:       bold;
-  }
-  
-  .main {
-    width:      980px;
-    margin:     100px auto;
-    padding:    100px;
-    box-shadow: 0 0 4px gray;
-    position:   relative;
-  }
-  
-  .success-message {
-    margin:      30px 0;
-    text-align:  center;
-  }
-  
-  
-  /******* フォームのinfoを非表示に *******/
-  .info {
-    display: none;
-  }
-  
+body {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+.header {
+  height: 70px;
+  background-color: #24292F;
+  width: 100%;
+}
+
+.header .header__content {
+  width: 100%;
+  margin: auto;
+  padding-left: 10px;
+}
+
+.header .header__logo {
+  color: white;
+  line-height: 70px;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.main {
+  width: 100%;
+  margin: 100px auto;
+  padding: 100px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: baseline;
+}
+
+.success-message {
+  margin: 30px 0;
+  text-align: center;
+}
+
+table,
+th,
+td {
+  border-left: none;
+  border-right: none;
+}
+
+th,
+td {
+  border-top: 1px solid #000;
+  border-bottom: 1px solid #000;
+}
+
+table {
+  position: relative;
+  border-collapse: collapse;
+  width: 90%;
+  float: left;
+  box-shadow: 0 0 4px gray;
+}
+
+.legend {
+  width: 90%;
+  float: left;
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.legend div {
+  margin-bottom: 10px;
+  padding: 5px;
+  font-size: 10px;
+}
+
+.legend div span {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  vertical-align: middle;
+  margin-right: 5px;
+}
+
+.table-div {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: flex-start;
+  margin: 0%;
+  padding: 0%;
+}
+
+/******* フォームのinfoを非表示に *******/
+.info {
+  display: none;
+}

--- a/public/stylesheets/todo.css
+++ b/public/stylesheets/todo.css
@@ -43,26 +43,95 @@ body {
   text-align: center;
 }
 
-table,
-th,
-td {
-  border-left: none;
-  border-right: none;
-}
-
-th,
-td {
-  border-top: 1px solid #000;
-  border-bottom: 1px solid #000;
-}
-
-table {
+.todo-div {
+  padding: 20px;
   position: relative;
-  border-collapse: collapse;
-  width: 90%;
-  float: left;
-  box-shadow: 0 0 4px gray;
+  display: flex;
+  flex-direction: column;
+  width: 80%;
+  justify-content: space-around;
+  align-items: center;
+  margin: auto;
 }
+
+.todo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  position: relative;
+  width: 100%;
+}
+
+.todo-item {
+  border-radius: 10px;
+  height: 100%;
+  width: 100%;
+  padding: 10px;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+.todo-content {
+  display: flex;
+  flex-direction: column;
+  margin-left: 20px;
+  flex: 1;
+}
+
+.todo-title {
+  font-size: 1.2em;
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+
+.todo-body {
+  margin-bottom: 5px;
+}
+
+.todo-dates {
+  display: flex;
+  flex-direction: column;
+  color: red;
+}
+
+.todo-status-category {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center; /* 中央寄せにするために変更 */
+  margin-right: 10px;
+}
+
+.todo-status {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  height: 100%;
+  width: 110px;
+}
+
+.todo-category {
+  position: relative;
+  bottom: 0; /* 右下に配置 */
+  right: 0;
+  width: 110px;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.category-color {
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+}
+
 
 .legend {
   width: 90%;
@@ -76,26 +145,16 @@ table {
   position: relative;
   margin-bottom: 10px;
   padding: 5px;
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .legend div span {
   display: inline-block;
-  width: 10px;
-  height: 10px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
   vertical-align: middle;
   margin-right: 5px;
-}
-
-.table-div {
-  position: relative;
-  width: 80%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-  align-items: center;
-  margin: auto;
-  padding: 0;
 }
 
 /******* フォームのinfoを非表示に *******/

--- a/public/stylesheets/todo.css
+++ b/public/stylesheets/todo.css
@@ -28,10 +28,10 @@ body {
 }
 
 .main {
-  width: 100%;
+  position: relative;
+  width: 80%;
   margin: 100px auto;
   padding: 100px;
-  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
@@ -73,6 +73,7 @@ table {
 }
 
 .legend div {
+  position: relative;
   margin-bottom: 10px;
   padding: 5px;
   font-size: 10px;
@@ -88,12 +89,13 @@ table {
 
 .table-div {
   position: relative;
+  width: 80%;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  align-items: flex-start;
-  margin: 0%;
-  padding: 0%;
+  align-items: center;
+  margin: auto;
+  padding: 0;
 }
 
 /******* フォームのinfoを非表示に *******/

--- a/public/stylesheets/todo.css
+++ b/public/stylesheets/todo.css
@@ -1,0 +1,46 @@
+/**
+ * to-do list
+ */
+
+ body {
+    margin:   0;
+    padding:  0;
+  }
+  
+  .header {
+    height:            70px;
+    background-color:  #24292F;
+    width:             100%;
+  }
+  
+  .header .header__content {
+    width:      1080px;
+    margin:     auto;
+  }
+  
+  .header .header__logo {
+    color:             white;
+    line-height:       70px;
+    font-size:         20px;
+    font-weight:       bold;
+  }
+  
+  .main {
+    width:      980px;
+    margin:     100px auto;
+    padding:    100px;
+    box-shadow: 0 0 4px gray;
+    position:   relative;
+  }
+  
+  .success-message {
+    margin:      30px 0;
+    text-align:  center;
+  }
+  
+  
+  /******* フォームのinfoを非表示に *******/
+  .info {
+    display: none;
+  }
+  


### PR DESCRIPTION
close #1 

# 変更点

- ToDoとCategoryのモデル定義のために、app/model/ 下に以下のファイルを追加
  - ToDo.scala
  - ToDoCategory.scala

- DB-scala間のto_doテーブルとto_do_categoryテーブルのマッピングのために、app/persistence/db/ 下に以下のファイルを追加
  - ToDo.scala
  - ToDoCategory.scala

- ToDoテーブルとToDoCategoryテーブルへのクエリ発行のために、app/persistence/ 下に以下のファイルを追加
  - ToDo.scala
  - ToDoCategory.scala

- todoリスト一覧表示のために、app/controllers/ 下に以下のファイル
  - ToDo.scala

  と、app/views/ 下に以下のファイルを追加
  - ToDo.scala.html

- todoリスト一覧表示ページのルーティングをconf/routesに追記